### PR TITLE
Content updates + record submitted and Gov Gateway screens

### DIFF
--- a/app/views/my-useful-page.html
+++ b/app/views/my-useful-page.html
@@ -1,0 +1,40 @@
+{% extends "layouts/main.html" %}
+
+{% block pageTitle %}
+  Question page template – {{ serviceName }} – GOV.UK Prototype Kit
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+  text: "Back",
+  href: "javascript:window.history.back()"
+}) }}
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        Heading or question goes here
+      </h1>
+
+      <form class="form" action="/path/of/next/page" method="post">
+
+        <p>
+          [Insert question content here - see the
+          <a href="https://design-system.service.gov.uk">GOV.UK Design System</a>
+          for examples]
+        </p>
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+
+      </form>
+
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v19_1/_routes.js
+++ b/app/views/v19_1/_routes.js
@@ -598,6 +598,11 @@ router.post('/index', function(req, res) {
   }
   })
 
+// GOV GATEWAY SIGNIN
+router.post('/gov-gateway-signin', function(req, res) {
+  res.redirect('index-homepage')
+})
+
 
 // --------------------------------------------------------------------------------------------------------
 
@@ -1145,6 +1150,18 @@ router.post('/check-answers-receiver', function(req, res) {
   }  
 })
 
+
+// WASTE RECORD TASKLIST - COMPELTED SECTIONS
+
+//--- RECEIVER SECTION COMPLETE
+router.post('/waste-record-receiver-complete', function(req, res) {
+  res.redirect('waste-record-submitted');
+})
+
+//--- CARRIER SECTION COMPLETE
+router.post('/waste-record-carrier-complete', function(req, res) {
+  res.redirect('waste-record-submitted');
+})
 
 
   

--- a/app/views/v19_1/bulk-errors-1.html
+++ b/app/views/v19_1/bulk-errors-1.html
@@ -7,7 +7,7 @@
 {% endblock %}
 
 {% block beforeContent %}
-  <div class="govuk-phase-banner">
+<!--   <div class="govuk-phase-banner">
     <p class="govuk-phase-banner__content">
         <strong class="govuk-tag govuk-phase-banner__content__tag">
         Prototype
@@ -33,7 +33,7 @@
         Check and correct errors
       </li>
     </ol>
-  </div>
+  </div> -->
 {% endblock %}
 
 {% block content %}

--- a/app/views/v19_1/gov-gateway-signin.html
+++ b/app/views/v19_1/gov-gateway-signin.html
@@ -35,28 +35,24 @@
 
     <form method="post" novalidate>
 
-        {{ govukInput({
-            label: {
-                text: "Government Gateway user ID"
-            },
-            hint: {
-                text: "This could be up to 12 characters."
-            },
-            classes: "govuk-!-width-one-half",
-            id: "userId",
-            name: "userId",
-            value: userId
-        })  }}
+      <!---- USER ID ---->
 
-        {{ govukInput({
-            label: {
-                text: "Password"
-            },
-            classes: "govuk-!-width-three-quarters",
-            id: "password",
-            name: "password",
-            value: password
-        }) }}
+      <div class="govuk-form-group">
+        <label class="govuk-label" for="govgateway-user">
+          Government Gateway user ID
+        </label>
+        <div class="govuk-hint">This could be up to 12 characters.</div>
+        <input class="govuk-input govuk-!-width-one-half" id="govgateway-user" name="govgateway-user" type="text">
+      </div>
+
+      <!---- PASSWORD ---->
+
+        <div class="govuk-form-group">
+          <label class="govuk-label" for="govgateway-user">
+            Password
+          </label>
+          <input class="govuk-input govuk-!-width-three-quarters" id="govgateway-user" name="govgateway-user" type="password">
+        </div>
 
         {{ govukButton({
             text: "Sign in"

--- a/app/views/v19_1/index-start.html
+++ b/app/views/v19_1/index-start.html
@@ -28,7 +28,7 @@
 
     <!-- SKIP DCID -->
 
-      <a href="/v19_1/index-homepage" role="button" draggable="false" class="govuk-button govuk-button--start" data-module="govuk-button">
+      <a href="/v19_1/gov-gateway-signin.html" role="button" draggable="false" class="govuk-button govuk-button--start" data-module="govuk-button">
       Start now
       <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
         <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />

--- a/app/views/v19_1/start-waste-record.html
+++ b/app/views/v19_1/start-waste-record.html
@@ -349,7 +349,31 @@
     <!-- end of section 7 -->
       <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
+    <!-------- ASSISTED DIGITAL DETAILS -------->
 
+    <details class="govuk-details" data-module="govuk-details">
+      <summary class="govuk-details__summary">
+        <span class="govuk-details__summary-text">
+          If you need help completing this record
+        </span>
+      </summary>
+      <div class="govuk-details__text">
+        <ul class="govuk-list">
+          <li>Telephone: 020 7946 0101</li>
+          <li>Monday to Friday, 8am to 6pm (except public holidays)</li>
+          <li>Saturday and Sunday, 10am to 4pm</li>
+        </ul>
+        <p class="govuk-body">
+          <a class="govuk-link" href="#">Find out about call charges</a>
+        </p>
+        <ul class="govuk-list">
+          <li><a class="govuk-link" href="#">name@example.com</a></li>
+          <li>We aim to respond within 2 working days</li>
+        </ul>
+      </div>
+    </details>
+
+    <!-------- ASSISTED DIGITAL END -------->
 
     <div class="govuk-!-padding-bottom-8"></div>
 

--- a/app/views/v19_1/unique-reference.html
+++ b/app/views/v19_1/unique-reference.html
@@ -51,7 +51,7 @@
           </label>
         </h1>
         <div id="reference-hint" class="govuk-hint">
-          Enter a reference that will help you to match this record to your own system in the future. You will get a service transaction number after you submit the waste record details.
+          Enter a reference that will help you to match this record to your own system in the future. You will get a waste record number after you submit the waste record details.
         </div>
 
           <input class="govuk-input" id="unique-ref" name="unique-ref" type="text" value="{{data['unique-ref']}}">

--- a/app/views/v19_1/waste-description.html
+++ b/app/views/v19_1/waste-description.html
@@ -21,9 +21,12 @@
               </label>
             </h1>
 
-            <div class="govuk-body">
+            <p class="govuk-body">
               Give the usual description of the waste. For example, PET bottles, HDPE pellets or OCC paper.
-            </div>
+            </p>
+
+            <p class="govuk-body">You’ll be asked to provide container details later.</p>
+            
             <textarea class="govuk-textarea govuk-js-character-count" id="describe-waste" name="describe-waste" rows="5" aria-describedby="describe-waste-hint with-hint-hint" maxlength="100" value="{{data['describe-waste']}}"></textarea>
           </div>
           <div id="describe-waste-hint" class="govuk-hint govuk-character-count__message">

--- a/app/views/v19_1/waste-record-aboutwaste-complete.html
+++ b/app/views/v19_1/waste-record-aboutwaste-complete.html
@@ -478,8 +478,34 @@ Waste record - About the waste section complete
 
       <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
-    <div class="govuk-!-padding-bottom-8"></div>
 
+    <!-------- ASSISTED DIGITAL DETAILS -------->
+
+    <details class="govuk-details" data-module="govuk-details">
+      <summary class="govuk-details__summary">
+        <span class="govuk-details__summary-text">
+          If you need help completing this record
+        </span>
+      </summary>
+      <div class="govuk-details__text">
+        <ul class="govuk-list">
+          <li>Telephone: 020 7946 0101</li>
+          <li>Monday to Friday, 8am to 6pm (except public holidays)</li>
+          <li>Saturday and Sunday, 10am to 4pm</li>
+        </ul>
+        <p class="govuk-body">
+          <a class="govuk-link" href="#">Find out about call charges</a>
+        </p>
+        <ul class="govuk-list">
+          <li><a class="govuk-link" href="#">name@example.com</a></li>
+          <li>We aim to respond within 2 working days</li>
+        </ul>
+      </div>
+    </details>
+
+    <!-------- ASSISTED DIGITAL END -------->
+
+    <div class="govuk-!-padding-bottom-8"></div>
 
     <!----- BUTTONS ----->
 

--- a/app/views/v19_1/waste-record-aboutwaste-prepopulated.html
+++ b/app/views/v19_1/waste-record-aboutwaste-prepopulated.html
@@ -525,7 +525,33 @@ Waste record - About the waste section complete
 
       <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
-    <div class="govuk-!-padding-bottom-8"></div>
+    <!-------- ASSISTED DIGITAL DETAILS -------->
+
+    <details class="govuk-details" data-module="govuk-details">
+      <summary class="govuk-details__summary">
+        <span class="govuk-details__summary-text">
+          If you need help completing this record
+        </span>
+      </summary>
+      <div class="govuk-details__text">
+        <ul class="govuk-list">
+          <li>Telephone: 020 7946 0101</li>
+          <li>Monday to Friday, 8am to 6pm (except public holidays)</li>
+          <li>Saturday and Sunday, 10am to 4pm</li>
+        </ul>
+        <p class="govuk-body">
+          <a class="govuk-link" href="#">Find out about call charges</a>
+        </p>
+        <ul class="govuk-list">
+          <li><a class="govuk-link" href="#">name@example.com</a></li>
+          <li>We aim to respond within 2 working days</li>
+        </ul>
+      </div>
+    </details>
+
+    <!-------- ASSISTED DIGITAL END -------->
+
+    <div class="govuk-!-padding-bottom-6"></div>
 
 
     <!----- BUTTONS ----->

--- a/app/views/v19_1/waste-record-carrier-complete.html
+++ b/app/views/v19_1/waste-record-carrier-complete.html
@@ -38,6 +38,8 @@ Waste record - Carrier details section complete
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
+        <form method="post">
+
         <span class="govuk-caption-l">Your reference: {{ data['unique-ref'] }}</span>
         <h1 class="govuk-heading-l">
             Waste record
@@ -902,24 +904,57 @@ Waste record - Carrier details section complete
 
         <a class="govuk-body govuk-link" href="receiver-confirm.html">Confirm or reject the waste you received and enter the relevant waste treatment codes</a>
 
-        <div class="govuk-!-padding-bottom-6"></div>
-
       <!-- end of section -->
 
-        <div class="govuk-!-padding-bottom-8"></div>
+      <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+
+      <div class="govuk-!-padding-bottom-6"></div>
+
+      <!-------- ASSISTED DIGITAL DETAILS -------->
+
+    <details class="govuk-details" data-module="govuk-details">
+        <summary class="govuk-details__summary">
+          <span class="govuk-details__summary-text">
+            If you need help completing this record
+          </span>
+        </summary>
+        <div class="govuk-details__text">
+          <ul class="govuk-list">
+            <li>Telephone: 020 7946 0101</li>
+            <li>Monday to Friday, 8am to 6pm (except public holidays)</li>
+            <li>Saturday and Sunday, 10am to 4pm</li>
+          </ul>
+          <p class="govuk-body">
+            <a class="govuk-link" href="#">Find out about call charges</a>
+          </p>
+          <ul class="govuk-list">
+            <li><a class="govuk-link" href="#">name@example.com</a></li>
+            <li>We aim to respond within 2 working days</li>
+          </ul>
+        </div>
+      </details>
+  
+      <!-------- ASSISTED DIGITAL END -------->
+
+        <div class="govuk-!-padding-bottom-6"></div>
 
         <!----- BUTTONS ----->
         <div class="govuk-button-group">
-            <a href="home-move-waste-uk.html">
-                <button class="govuk-button govuk-button--secondary" data-module="govuk-button">
-                    Return to this note later
-                </button>
-            </a>
+            {{ govukButton({
+            text: "Submit this waste record"
+            }) }}
+
+            {{ govukButton({
+            text: "Return to this record later",
+            classes: "govuk-button--secondary"
+            }) }}
         </div>
 
     </div>
 
     <div class="govuk-grid-column-one-third">
+
+    </form>
 
     </div>
 </div>

--- a/app/views/v19_1/waste-record-complete-AAAA4712.html
+++ b/app/views/v19_1/waste-record-complete-AAAA4712.html
@@ -41,7 +41,7 @@ Waste record - Reciever section complete
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-        <span class="govuk-caption-l">Waste record ID AAAA-4712</span>
+        <span class="govuk-caption-l">Waste record number AAAA-4712</span>
         <h1 class="govuk-heading-l">
             Waste record details
         </h1>

--- a/app/views/v19_1/waste-record-complete-success.html
+++ b/app/views/v19_1/waste-record-complete-success.html
@@ -8,26 +8,32 @@ Waste record completed
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+
+      <!-- PANEL -->
       
         {{ govukPanel({
           titleText: "Waste record completed",
-          html: "Waste record ID <strong>WTS191023-00001/1</strong>"
+          html: "Waste record number<br> <strong>AAAA-4712</strong>"
         }) }}
 
-        <p class="govuk-body govuk-!-padding-top-2">You have confirmed the waste details for this movement and acknowledged receipt of it.</p>
-  
-        <h3 class="govuk-heading-s govuk-!-padding-top-2">
-          What happens next
-        </h3>
-  
-          <p class="govuk-body">You can access the waste record at a later date, using the waste record ID to find it. </p>
+        <!-- DETAILS -->
 
+        <p class="govuk-body govuk-!-padding-top-4">We’ve sent a confirmation email to <b>email@emailaddress.com</b>.</p>
+
+  
+          <p class="govuk-body">We’ve also sent these details to the relevant UK regulatory authority, You do not need to send them anything else.</p>
+
+        <!-- LINKS -->
   
         <p class="govuk-body govuk-!-padding-top-6">
           <a href="in-progress-add-details.html" class="govuk-link">Confirm and complete another waste record</a>
         </p>
 
         <p class="govuk-body">
+          <a href="completed-waste-movements.html" class="govuk-link">View all completed records</a>
+        </p>
+
+        <p class="govuk-body govuk-!-padding-top-3">
           <a href="index-homepage.html" class="govuk-link">Return to your account home screen</a>
         </p>
 

--- a/app/views/v19_1/waste-record-producer-complete.html
+++ b/app/views/v19_1/waste-record-producer-complete.html
@@ -621,7 +621,33 @@ Waste record - Producer and collection section complete
                     <!-- end of section -->
                     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
-                    <div class="govuk-!-padding-bottom-8"></div>
+                    <!-------- ASSISTED DIGITAL DETAILS -------->
+
+                    <details class="govuk-details" data-module="govuk-details">
+                        <summary class="govuk-details__summary">
+                        <span class="govuk-details__summary-text">
+                            If you need help completing this record
+                        </span>
+                        </summary>
+                        <div class="govuk-details__text">
+                        <ul class="govuk-list">
+                            <li>Telephone: 020 7946 0101</li>
+                            <li>Monday to Friday, 8am to 6pm (except public holidays)</li>
+                            <li>Saturday and Sunday, 10am to 4pm</li>
+                        </ul>
+                        <p class="govuk-body">
+                            <a class="govuk-link" href="#">Find out about call charges</a>
+                        </p>
+                        <ul class="govuk-list">
+                            <li><a class="govuk-link" href="#">name@example.com</a></li>
+                            <li>We aim to respond within 2 working days</li>
+                        </ul>
+                        </div>
+                    </details>
+                
+                    <!-------- ASSISTED DIGITAL END -------->
+
+                    <div class="govuk-!-padding-bottom-6"></div>
 
                     <!----- BUTTONS ----->
                     <div class="govuk-button-group">

--- a/app/views/v19_1/waste-record-receiver-complete.html
+++ b/app/views/v19_1/waste-record-receiver-complete.html
@@ -38,6 +38,8 @@ Waste record - Reciever section complete
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
+        <form method="post">
+
         <span class="govuk-caption-l">Your reference: {{ data['unique-ref'] }}</span>
         <h1 class="govuk-heading-l">
             Waste record details
@@ -783,12 +785,40 @@ Waste record - Reciever section complete
 
         <a class="govuk-body govuk-link" href="receiver-confirm.html">Confirm or reject the waste you received and enter the relevant waste treatment codes</a>
 
-        <div class="govuk-!-padding-bottom-6"></div>
-
       <!-- end of section -->
 
+      <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
-        <div class="govuk-!-padding-bottom-8"></div>
+      <div class="govuk-!-padding-bottom-6"></div>
+
+      <!-------- ASSISTED DIGITAL DETAILS -------->
+
+        <details class="govuk-details" data-module="govuk-details">
+            <summary class="govuk-details__summary">
+            <span class="govuk-details__summary-text">
+                If you need help completing this record
+            </span>
+            </summary>
+            <div class="govuk-details__text">
+            <ul class="govuk-list">
+                <li>Telephone: 020 7946 0101</li>
+                <li>Monday to Friday, 8am to 6pm (except public holidays)</li>
+                <li>Saturday and Sunday, 10am to 4pm</li>
+            </ul>
+            <p class="govuk-body">
+                <a class="govuk-link" href="#">Find out about call charges</a>
+            </p>
+            <ul class="govuk-list">
+                <li><a class="govuk-link" href="#">name@example.com</a></li>
+                <li>We aim to respond within 2 working days</li>
+            </ul>
+            </div>
+        </details>
+    
+        <!-------- ASSISTED DIGITAL END -------->
+
+
+        <div class="govuk-!-padding-bottom-6"></div>
 
         <!----- BUTTONS ----->
         <div class="govuk-button-group">
@@ -805,6 +835,8 @@ Waste record - Reciever section complete
     </div>
 
     <div class="govuk-grid-column-one-third">
+
+    </form>
 
     </div>
 </div>

--- a/app/views/v19_1/waste-record-receiverconfirm-complete.html
+++ b/app/views/v19_1/waste-record-receiverconfirm-complete.html
@@ -38,7 +38,7 @@ Waste record - Reciever section complete
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-        <span class="govuk-caption-l">Your reference: {{ data['unique-ref'] }}</span>
+        <span class="govuk-caption-l">Waste record number AAAA-4712</span>
         <h1 class="govuk-heading-l">
             Waste record details
         </h1>
@@ -1480,8 +1480,33 @@ Waste record - Reciever section complete
 
         <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible"> -->
 
+        <!-------- ASSISTED DIGITAL DETAILS -------->
 
-        <div class="govuk-!-padding-bottom-8"></div>
+        <details class="govuk-details" data-module="govuk-details">
+            <summary class="govuk-details__summary">
+            <span class="govuk-details__summary-text">
+                If you need help completing this record
+            </span>
+            </summary>
+            <div class="govuk-details__text">
+            <ul class="govuk-list">
+                <li>Telephone: 020 7946 0101</li>
+                <li>Monday to Friday, 8am to 6pm (except public holidays)</li>
+                <li>Saturday and Sunday, 10am to 4pm</li>
+            </ul>
+            <p class="govuk-body">
+                <a class="govuk-link" href="#">Find out about call charges</a>
+            </p>
+            <ul class="govuk-list">
+                <li><a class="govuk-link" href="#">name@example.com</a></li>
+                <li>We aim to respond within 2 working days</li>
+            </ul>
+            </div>
+        </details>
+    
+        <!-------- ASSISTED DIGITAL END -------->
+
+        <div class="govuk-!-padding-bottom-6"></div>
 
         <!----- BUTTONS ----->
         <form method="POST" action="">

--- a/app/views/v19_1/waste-record-submitted.html
+++ b/app/views/v19_1/waste-record-submitted.html
@@ -1,0 +1,55 @@
+{% extends "../layout.html" %}
+
+{% block pageTitle %}
+Waste record submitted
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+        <!-- PANEL -->
+      
+        {{ govukPanel({
+          titleText: "Waste record submitted",
+          html: "Your waste record number is<br> <strong>AAAA-4712</strong>"
+        }) }}
+
+        <!-- DETAILS -->
+
+        <p class="govuk-body govuk-!-padding-top-4">We’ve sent a confirmation email to <b>email@emailaddress.com</b>.</p>
+
+  
+          <p class="govuk-body">We’ve also sent these details to the following contacts named on the record:</p>
+          <ul class="govuk-body">
+            <li>Ellie Davies at Waste Carriers Ltd</li>
+            <li>Maria Fontaine at Waste Receivers Ltd</li>
+          </ul>
+
+          <p class="govuk-body">You should make a note of the waste record number in case you need to refer to it.</p>
+
+        <h2 class="govuk-heading-s">Update this waste record with actual details</h2>
+        <p class="govuk-body">If you’ve provided estimates, you’ll need to provide actual details as soon as possible. This includes the:</p>
+          <ul class="govuk-body">
+            <li>weight or volume</li>
+            <li>collection date</li>
+            <li>vehicle registration</li>
+          </ul>
+
+        <div class="govuk-!-padding-bottom-6"></div>
+
+        <!-- LINKS -->
+
+        <p class="govuk-body">
+          <a href="home-move-waste-uk.html" class="govuk-link">Submit another waste record</a>
+        </p>
+
+        <p class="govuk-body govuk-!-padding-top-3">
+          <a href="index-homepage.html" class="govuk-link">Return to your account home screen</a>
+        </p>
+
+    </div>
+  </div>
+
+{% endblock %}


### PR DESCRIPTION
Added Gov Gateway sign in screen (for returning users that have accounts) Added record submitted screen to complete the 'controller' journey

moved waste role select before unique ref screen

Content updates
- consistent reference to record 'number' not ID
- first pass at submitted and completed 'success' screens -